### PR TITLE
Handle Missing Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ We print a shell prompt (`$ `) and wait for the user's input.
 
 ---
 
+## Stage 2: Handle Missing Commands
+
+We handle the case where the user enters a command that doesn't exist (which right now, is every command!). We print an error message and continue to wait for the user's input instead of letting the shell crash.
+
+---
+
 ## 📕 References
 
 - https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,4 +17,16 @@ fn main() {
     // Wait for user input and read it into a String variable.
     let mut input = String::new();
     io::stdin().read_line(&mut input).unwrap();
+
+    // Split the input into a vector
+    let args: Vec<&str> = input.trim().split_whitespace().collect();
+
+    // Extract the command name from the vector
+    let command = args.get(0);
+
+    // Act on the command-name
+    match command {
+        Some(x) => println!("{}: command not found", x),
+        None => println!("No command provided"),
+    }
 }


### PR DESCRIPTION
Handle the case where the user enters a command that doesn't exist (which right now, is every command!). We print an error message and continue to wait for the user's input instead of letting the shell crash.